### PR TITLE
LMS - Upgrading the AWS provider version to the latest

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -82,10 +82,10 @@ output "tags_as_list_of_maps" {
     EOT
 }
 
-output "descriptors" {
-  value       = local.descriptors
-  description = "Map of descriptors as configured by `descriptor_formats`"
-}
+#output "descriptors" {
+#  value       = local.descriptors
+#  description = "Map of descriptors as configured by `descriptor_formats`"
+#}
 
 output "normalized_context" {
   value       = local.output_context

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.6.0, < 1.7.0"
 }


### PR DESCRIPTION
Updated Terraform version from 0.13.0 to 1.6.0 - 1.7.0 
Updated Outputs.tf by removing the comments from outputs block Descriptors.